### PR TITLE
add api code

### DIFF
--- a/query_tcga/api.py
+++ b/query_tcga/api.py
@@ -1,8 +1,58 @@
+import pandas as pd
+import io
+import logging
+from query_tcga.log_with import log_with
+from query_tcga import defaults 
+from query_tcga.defaults import GDC_API_ENDPOINT
+from query_tcga import parameters as _params
+from query_tcga.cache import requests_get
+from query_tcga.helpers import _compute_start_given_page, _convert_to_list
 
-
-
+logging.basicConfig()
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
 
 #### ---- utilities for interacting with the GDC api ---- 
+
+@log_with()
+def _get_data(endpoint_name, arg=None,
+              project_name=None, fields=None, size=defaults.DEFAULT_SIZE, page=1,
+              data_category=None, query_args={}, verify=False, **kwargs):
+    """ Get single result from querying GDC api endpoint
+
+    >>> file = _get_data(endpoint='files', data_category='Clinical', query_args=dict(file_id=df['case_uuid'][0]))
+    <Response [200]>
+    """
+    endpoint = GDC_API_ENDPOINT.format(endpoint=endpoint_name)
+    if arg:
+        endpoint = endpoint+'/{}'.format(arg)
+        params = dict()
+    else:
+        ## prep extra-params, including `from` param, as dict
+        from_param = _compute_start_given_page(page=page, size=size)
+        extra_params = {
+            'from': from_param,
+            }
+        if fields:
+            extra_params.update({'fields': ','.join(_convert_to_list(fields))})
+        if dict(**kwargs):
+            ## TODO check on whether this handles redundant param spec 
+            ## correctly
+            extra_params.update(dict(**kwargs))        
+        params = _params.construct_parameters(project_name=project_name,
+                                             size=size,
+                                             endpoint_name=endpoint_name,
+                                             data_category=data_category,
+                                             query_args=query_args,
+                                             verify=verify,
+                                             **extra_params
+                                             )
+
+    # requests URL-encodes automatically
+    response = requests_get(endpoint, params=params)
+    response.raise_for_status()
+    return response
+
 
 @log_with()
 def _get_case_data(size=1, page=1, case_uuid=None, project_name=None, fields=None, query_args={}):
@@ -16,10 +66,11 @@ def _get_case_data(size=1, page=1, case_uuid=None, project_name=None, fields=Non
         endpoint = endpoint+'/{}'.format(case_uuid)
         params = dict()
     else:
-        params = _construct_parameters(project_name=project_name,
-                                     size=size, endpoint_name='cases',
-                                    query_args={})
         from_param = _compute_start_given_page(page=page, size=size)
+        params = _params.construct_parameters(project_name=project_name,
+                                              size=size,
+                                              endpoint_name='cases',
+                                              query_args=query_args)
         extra_params = {
             'from': from_param,
             }
@@ -27,38 +78,7 @@ def _get_case_data(size=1, page=1, case_uuid=None, project_name=None, fields=Non
             extra_params.update({'fields': ','.join(_convert_to_list(fields))})
             params=dict(params, **extra_params)
     # requests URL-encodes automatically
-    response = requests.get(endpoint, params=params)
-    response.raise_for_status()
-    return response
-
-
-@log_with()
-def _get_data(endpoint_name, arg=None, project_name=None, fields=None, size=100, page=1, data_category=None, query_args={}, verify=False, **kwargs):
-    """ Get single result from querying GDC api endpoint
-
-    >>> file = _get_data(endpoint='files', data_category='Clinical', query_args=dict(file_id=df['case_uuid'][0]))
-    <Response [200]>
-    """
-    endpoint = GDC_API_ENDPOINT.format(endpoint=endpoint_name)
-    if arg:
-        endpoint = endpoint+'/{}'.format(arg)
-        params = dict()
-    else:
-        params = params.construct_parameters(project_name=project_name,
-                                      size=size, endpoint_name=endpoint_name,
-                                      data_category=None,
-                                      query_args={}, verify=verify)
-        from_param = _compute_start_given_page(page=page, size=size)
-        extra_params = {
-            'from': from_param,
-            }
-        if dict(**kwargs):
-            extra_params.update(dict(**kwargs))
-        if fields:
-            extra_params.update({'fields': ','.join(_convert_to_list(fields))})
-            params=dict(params, **extra_params)
-    # requests URL-encodes automatically
-    response = requests.get(endpoint, params=params)
+    response = requests_get(endpoint, params=params)
     response.raise_for_status()
     return response
 
@@ -70,7 +90,7 @@ def _get_sample_data():
 
 
 @log_with()
-def _get_file_metadata(project_name=None, data_category=None, fields=DEFAULT_FILE_FIELDS, query_args={}, **kwargs):
+def _get_file_metadata(project_name=None, data_category=None, fields=defaults.DEFAULT_FILE_FIELDS, query_args={}, **kwargs):
     response = _get_data(endpoint_name='files', data_category=data_category,
                     query_args=query_args, fields=fields, format='tsv', **kwargs)
     df = pd.read_csv(io.StringIO(response.text), sep='\t')
@@ -83,17 +103,16 @@ def _describe_samples(case_ids,
                       query_args={},
                       **kwargs):
     
-    df = list()
     for case_id in _convert_to_list(case_ids):
         sample_df = list()
-        samples = qt._get_data(endpoint='cases',
+        samples = _get_data(endpoint='cases',
                                fields='sample_ids',
                                query_args=dict(case_id=case_id, **query_args),
                                **kwargs
                                )
         sample_ids = list()
         [sample_ids.extend(hit['sample_ids']) for hit in samples.json()['data']['hits']]
-        sample_data = qt._get_data(endpoint='samples',
+        sample_data = _get_data(endpoint='samples',
                                    query_args=dict(sample_id=sample_ids),
                                    )
         sample_df.append(sample_data)

--- a/query_tcga/api.py
+++ b/query_tcga/api.py
@@ -1,0 +1,100 @@
+
+
+
+
+#### ---- utilities for interacting with the GDC api ---- 
+
+@log_with()
+def _get_case_data(size=1, page=1, case_uuid=None, project_name=None, fields=None, query_args={}):
+    """ Get single case json matching project_name & categories
+
+    >>> _get_case_data(project_name='TCGA-BLCA', data_category=['Clinical'], size=5)
+    <Response [200]>
+    """
+    endpoint = GDC_API_ENDPOINT.format(endpoint='cases')
+    if case_uuid:
+        endpoint = endpoint+'/{}'.format(case_uuid)
+        params = dict()
+    else:
+        params = _construct_parameters(project_name=project_name,
+                                     size=size, endpoint_name='cases',
+                                    query_args={})
+        from_param = _compute_start_given_page(page=page, size=size)
+        extra_params = {
+            'from': from_param,
+            }
+        if fields:
+            extra_params.update({'fields': ','.join(_convert_to_list(fields))})
+            params=dict(params, **extra_params)
+    # requests URL-encodes automatically
+    response = requests.get(endpoint, params=params)
+    response.raise_for_status()
+    return response
+
+
+@log_with()
+def _get_data(endpoint_name, arg=None, project_name=None, fields=None, size=100, page=1, data_category=None, query_args={}, verify=False, **kwargs):
+    """ Get single result from querying GDC api endpoint
+
+    >>> file = _get_data(endpoint='files', data_category='Clinical', query_args=dict(file_id=df['case_uuid'][0]))
+    <Response [200]>
+    """
+    endpoint = GDC_API_ENDPOINT.format(endpoint=endpoint_name)
+    if arg:
+        endpoint = endpoint+'/{}'.format(arg)
+        params = dict()
+    else:
+        params = params.construct_parameters(project_name=project_name,
+                                      size=size, endpoint_name=endpoint_name,
+                                      data_category=None,
+                                      query_args={}, verify=verify)
+        from_param = _compute_start_given_page(page=page, size=size)
+        extra_params = {
+            'from': from_param,
+            }
+        if dict(**kwargs):
+            extra_params.update(dict(**kwargs))
+        if fields:
+            extra_params.update({'fields': ','.join(_convert_to_list(fields))})
+            params=dict(params, **extra_params)
+    # requests URL-encodes automatically
+    response = requests.get(endpoint, params=params)
+    response.raise_for_status()
+    return response
+
+
+@log_with()
+def _get_sample_data():
+    return True
+
+
+
+@log_with()
+def _get_file_metadata(project_name=None, data_category=None, fields=DEFAULT_FILE_FIELDS, query_args={}, **kwargs):
+    response = _get_data(endpoint_name='files', data_category=data_category,
+                    query_args=query_args, fields=fields, format='tsv', **kwargs)
+    df = pd.read_csv(io.StringIO(response.text), sep='\t')
+    return df
+
+
+@log_with()
+def _describe_samples(case_ids,
+                      data_category,
+                      query_args={},
+                      **kwargs):
+    
+    df = list()
+    for case_id in _convert_to_list(case_ids):
+        sample_df = list()
+        samples = qt._get_data(endpoint='cases',
+                               fields='sample_ids',
+                               query_args=dict(case_id=case_id, **query_args),
+                               **kwargs
+                               )
+        sample_ids = list()
+        [sample_ids.extend(hit['sample_ids']) for hit in samples.json()['data']['hits']]
+        sample_data = qt._get_data(endpoint='samples',
+                                   query_args=dict(sample_id=sample_ids),
+                                   )
+        sample_df.append(sample_data)
+    return sample_df

--- a/query_tcga/api.py
+++ b/query_tcga/api.py
@@ -55,32 +55,17 @@ def _get_data(endpoint_name, arg=None,
 
 
 @log_with()
-def _get_case_data(size=1, page=1, case_uuid=None, project_name=None, fields=None, query_args={}):
+def _get_case_data(arg=None,
+              project_name=None, fields=None, size=defaults.DEFAULT_SIZE, page=1,
+              data_category=None, query_args={}, verify=False, **kwargs):
     """ Get single case json matching project_name & categories
 
     >>> _get_case_data(project_name='TCGA-BLCA', data_category=['Clinical'], size=5)
     <Response [200]>
     """
-    endpoint = GDC_API_ENDPOINT.format(endpoint='cases')
-    if case_uuid:
-        endpoint = endpoint+'/{}'.format(case_uuid)
-        params = dict()
-    else:
-        from_param = _compute_start_given_page(page=page, size=size)
-        params = _params.construct_parameters(project_name=project_name,
-                                              size=size,
-                                              endpoint_name='cases',
-                                              query_args=query_args)
-        extra_params = {
-            'from': from_param,
-            }
-        if fields:
-            extra_params.update({'fields': ','.join(_convert_to_list(fields))})
-            params=dict(params, **extra_params)
-    # requests URL-encodes automatically
-    response = requests_get(endpoint, params=params)
-    response.raise_for_status()
-    return response
+    return _get_data(endpoint='cases', arg=arg, project_name=project_name, fields=fields, size=size,
+                    page=page, data_category=data_category, query_args=query_args,
+                    verify=verify, **kwargs)
 
 
 @log_with()
@@ -90,7 +75,8 @@ def _get_sample_data():
 
 
 @log_with()
-def _get_file_metadata(project_name=None, data_category=None, fields=defaults.DEFAULT_FILE_FIELDS, query_args={}, **kwargs):
+def _get_file_metadata(project_name=None, data_category=None, fields=defaults.DEFAULT_FILE_FIELDS,
+                       query_args={}, **kwargs):
     response = _get_data(endpoint_name='files', data_category=data_category,
                     query_args=query_args, fields=fields, format='tsv', **kwargs)
     df = pd.read_csv(io.StringIO(response.text), sep='\t')

--- a/query_tcga/helpers.py
+++ b/query_tcga/helpers.py
@@ -1,0 +1,32 @@
+
+from query_tcga.log_with import log_with
+
+@log_with()
+def _compute_start_given_page(page, size):
+    """ compute start / from position given page & size
+    """
+    return (page*size+1)
+
+@log_with()
+def _convert_to_list(x):
+    """ Convert x to a list if not already a list
+
+    Examples
+    -----------
+
+    >>> _convert_to_list('Clinical')
+    ['Clinical']
+    >>> _convert_to_list(['Clinical'])
+    ['Clinical']
+    >>> _convert_to_list(('Clinical','Biospecimen'))
+    ['Clinical', 'Biospecimen']
+
+    """
+    if not(x):
+        return(None)
+    elif isinstance(x, list):
+        return(x)
+    elif isinstance(x, str):
+        return([x])
+    else:
+        return(list(x))

--- a/query_tcga/query_tcga.py
+++ b/query_tcga/query_tcga.py
@@ -1,5 +1,3 @@
-import requests
-import json
 import os
 import subprocess
 import pandas as pd
@@ -12,9 +10,9 @@ from query_tcga.log_with import log_with
 from query_tcga import defaults 
 from query_tcga.defaults import GDC_API_ENDPOINT
 from query_tcga import parameters as _params
-from query_tcga import error_handling as _errors
 from query_tcga import cache
 from query_tcga.cache import requests_get
+from query_tcga.helers import _compute_start_given_page
 
 logging.basicConfig()
 log = logging.getLogger(__name__)
@@ -29,11 +27,6 @@ cache.setup_cache()
 ## 4. transform files to format needed by Cohorts (not done)
 
 
-@log_with()
-def _compute_start_given_page(page, size):
-    """ compute start / from position given page & size
-    """
-    return (page*size+1)
 
 
 @log_with()

--- a/query_tcga/query_tcga.py
+++ b/query_tcga/query_tcga.py
@@ -12,7 +12,7 @@ from query_tcga.defaults import GDC_API_ENDPOINT
 from query_tcga import parameters as _params
 from query_tcga import cache
 from query_tcga.cache import requests_get
-from query_tcga.helers import _compute_start_given_page
+from query_tcga.helpers import _compute_start_given_page
 
 logging.basicConfig()
 log = logging.getLogger(__name__)
@@ -233,7 +233,7 @@ def download_from_manifest(manifest_file=None, manifest_contents=None,
         if subprocess.check_call(exe_bash, cwd=data_dir):
             subprocess.call(exe_bash, cwd=data_dir)
         # verify that all files in original manifest have been downloaded
-        downloaded = _verify_download(io.StringIO(all_manifest_contents), data_dir=data_dir)
+        downloaded = _verify_download(manifest_contents=all_manifest_contents, data_dir=data_dir)
     finally:
         manifest_file.close()
     return downloaded
@@ -339,10 +339,6 @@ def _read_manifest_data(manifest_file):
     return manifest_data
 
 
-class FailedDownloadError(ValueError):
-    pass
-
-
 @log_with()
 def _verify_download_single_file(row, data_dir):
     """ Verify that the file indicated in the manifest exists in data_dir
@@ -378,7 +374,7 @@ def _characterize_downloads(data_dir, manifest_file=None, manifest_contents=None
     failed_downloads = list()
     downloads = list()
     for i, row in manifest_data.iterrows():
-        file_name, success = _verify_download_single_file(row, data_dir=data_dir)
+        file_name, success = _verify_download_single_file(row=row, data_dir=data_dir)
         if success:
             downloads.append(file_name)
         else:

--- a/query_tcga/samples.py
+++ b/query_tcga/samples.py
@@ -1,0 +1,54 @@
+
+
+#### ---- download other files ----
+
+@log_with()
+def download_wxs_files(project_name, query_args={}, **kwargs):
+    """ Download sequencing files for this project to the current working directory
+        1. Query API to get manifest file containing all files matching criteria
+        2. Use gdc-client to download files to current working directory
+        3. Verify that files downloaded as expected
+
+    Parameters
+    -----------
+      project_name (string, required): Name of project, ie 'TCGA-BLCA', 'TCGA-BRCA', etc
+      data_dir (string, optional): directory in which to save downloaded files. defaults to 'data/gdc'
+      query_args (dict, optional): other filters to apply (e.g. experimental_strategy=["WXS", "RNA-Seq", "Genotyping Array", "miRNA-Seq"])
+
+    Other parameters (mostly useful for testing)
+    -----------
+      verify (boolean, optional): if True, verify each name-value pair in the query_args dict
+      page_size (int, optional): how many records to list per page (default 50)
+      max_pages (int, optional): how many pages of records to download (default: all, by specifying value of None)
+
+    """
+    files = download_files(project_name=project_name, data_category=['Raw Sequencing Data'],
+             query_args=query_args.update(dict(experimental_strategy='WXS')), **kwargs)
+
+    return files
+
+
+@log_with()
+def download_vcf_files(project_name, data_format='VCF', query_args={}, **kwargs):
+    """ Download VCF files for this project to the DATA_DIR directory
+        1. Query API to get manifest file containing all files matching criteria
+        2. Use gdc-client to download files to current working directory
+        3. Verify that files downloaded as expected
+
+    Parameters
+    -----------
+      project_name (string, required): Name of project, ie 'TCGA-BLCA', 'TCGA-BRCA', etc
+      data_dir (string, optional): directory in which to save downloaded files. defaults to 'data/gdc'
+      query_args (dict, optional): other filters to apply (e.g. experimental_strategy=["WXS", "RNA-Seq", "Genotyping Array", "miRNA-Seq"])
+
+    Other parameters (mostly useful for testing)
+    -----------
+      verify (boolean, optional): if True, verify each name-value pair in the query_args dict
+      page_size (int, optional): how many records to list per page (default 50)
+      max_pages (int, optional): how many pages of records to download (default: all, by specifying value of None)
+
+    """
+    files = download_files(project_name=project_name, data_category=['Simple Nucleotide Variation'],
+             query_args=query_args.update(dict(data_format=data_format)), **kwargs)
+
+    return files

--- a/query_tcga/wxs_samples.py
+++ b/query_tcga/wxs_samples.py
@@ -1,0 +1,54 @@
+
+
+#### ---- download other files ----
+
+@log_with()
+def download_wxs_files(project_name, query_args={}, **kwargs):
+    """ Download sequencing files for this project to the current working directory
+        1. Query API to get manifest file containing all files matching criteria
+        2. Use gdc-client to download files to current working directory
+        3. Verify that files downloaded as expected
+
+    Parameters
+    -----------
+      project_name (string, required): Name of project, ie 'TCGA-BLCA', 'TCGA-BRCA', etc
+      data_dir (string, optional): directory in which to save downloaded files. defaults to 'data/gdc'
+      query_args (dict, optional): other filters to apply (e.g. experimental_strategy=["WXS", "RNA-Seq", "Genotyping Array", "miRNA-Seq"])
+
+    Other parameters (mostly useful for testing)
+    -----------
+      verify (boolean, optional): if True, verify each name-value pair in the query_args dict
+      page_size (int, optional): how many records to list per page (default 50)
+      max_pages (int, optional): how many pages of records to download (default: all, by specifying value of None)
+
+    """
+    files = download_files(project_name=project_name, data_category=['Raw Sequencing Data'],
+             query_args=query_args.update(dict(experimental_strategy='WXS')), **kwargs)
+
+    return files
+
+
+@log_with()
+def download_vcf_files(project_name, data_format='VCF', query_args={}, **kwargs):
+    """ Download VCF files for this project to the DATA_DIR directory
+        1. Query API to get manifest file containing all files matching criteria
+        2. Use gdc-client to download files to current working directory
+        3. Verify that files downloaded as expected
+
+    Parameters
+    -----------
+      project_name (string, required): Name of project, ie 'TCGA-BLCA', 'TCGA-BRCA', etc
+      data_dir (string, optional): directory in which to save downloaded files. defaults to 'data/gdc'
+      query_args (dict, optional): other filters to apply (e.g. experimental_strategy=["WXS", "RNA-Seq", "Genotyping Array", "miRNA-Seq"])
+
+    Other parameters (mostly useful for testing)
+    -----------
+      verify (boolean, optional): if True, verify each name-value pair in the query_args dict
+      page_size (int, optional): how many records to list per page (default 50)
+      max_pages (int, optional): how many pages of records to download (default: all, by specifying value of None)
+
+    """
+    files = download_files(project_name=project_name, data_category=['Simple Nucleotide Variation'],
+             query_args=query_args.update(dict(data_format=data_format)), **kwargs)
+
+    return files

--- a/tests/test_query_tcga.py
+++ b/tests/test_query_tcga.py
@@ -4,6 +4,7 @@ import pytest
 import shutil
 import pandas as pd
 import requests
+from query_tcga import error_handling as errors
 from query_tcga.log_with import log_with
 import logging
 
@@ -85,7 +86,7 @@ def test_download_files_using_n():
 def _rmdir_if_exists(*args, **kwargs):
     try:
         shutil.rmtree(*args, **kwargs)
-    except FileNotFoundError:
+    except errors.FileNotFoundError:
         pass
 
 @manifest
@@ -109,17 +110,17 @@ def test_get_clinical_data():
 @manifest
 def test_list_failed_downloads():
     _rmdir_if_exists(DATA_DIR)
-    manifest_data = qt.get_manifest(project_name='TCGA-BLCA', data_category='Clinical', pages=1, size=5)
-    failed = qt._list_failed_downloads(manifest_data=manifest_data, data_dir=DATA_DIR)
+    manifest_contents = qt.get_manifest(project_name='TCGA-BLCA', data_category='Clinical', n=5)
+    failed = qt._list_failed_downloads(manifest_contents=manifest_contents, data_dir=DATA_DIR)
     assert len(failed) == 5
     qt.download_clinical_files(project_name='TCGA-BLCA', n=5, data_dir=DATA_DIR)
-    new_failed = qt._list_failed_downloads(manifest_data=manifest_data, data_dir=DATA_DIR)
+    new_failed = qt._list_failed_downloads(manifest_contents=manifest_contents, data_dir=DATA_DIR)
     assert isinstance(new_failed, list)
     assert len(new_failed) == 0
 
 
 def test_download_from_manifest():
-    manifest_contents = qt.get_manifest(project_name='TCGA-BLCA', data_category='Clinical', pages=2, size=2)
+    manifest_contents = qt.get_manifest(project_name='TCGA-BLCA', data_category='Clinical', n=5)
     downloaded = qt.download_from_manifest(manifest_contents=manifest_contents, data_dir=DATA_DIR)
     assert isinstance(downloaded, list)
     assert len(manifest_contents.splitlines()) == len(downloaded)+1


### PR DESCRIPTION
Add a generic '_get_data' function to query the api. Duplicates some functionality in [pygdc](http://github.com/hammerlab/pygdc)'s [get_endpoint](https://github.com/hammerlab/pygdc/blob/master/pygdc/api.py#L12-L29), with slight differences in approach.

Examples of extended functionality : 
1. kwargs to specify other options (e.g. format, manifest_file, etc)
2. arg option, to allow for a non-keyword argument

Differences in approach (no pref here just noting for reference)
1. this version processes arguments internally rather than through filters object
2. this version returns response object, rather than returning parsed_response
3. pygdc version renames 'from' param to 'start'
4. this version manages pagination, whereas pygdc version takes only start (with pagination managed in `_get_endpoint_results`)
